### PR TITLE
Fix: file name too long to be saved.

### DIFF
--- a/audioldm2/utils.py
+++ b/audioldm2/utils.py
@@ -64,7 +64,10 @@ def save_wave(waveform, savepath, name="outwav", samplerate=16000):
                 )
         else:
             fname = "%s.wav" % os.path.basename(name[i]) if (not ".wav" in name[i]) else os.path.basename(name[i]).split(".")[0]
-            
+            # Avoid the file name too long to be saved
+            if len(fname) > 255:
+                fname = f"{hex(hash(fname))}.wav"
+
         path = os.path.join(
             savepath, fname
         )


### PR DESCRIPTION
If the `--text` and `--transcription` were too long (longer than 255), it would raise a `System error` because the length of filename exceeds the `$PATH_MAX` of OS.