### PR TITLE
Resolve `AttributeError: module 'gradio' has no attribute 'Box'`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ REQUIRED = [
     "torchaudio>=0.13.0",
     "torchvision>=0.14.0",
     "tqdm",
-    "gradio",
+    "gradio<4",
     "pyyaml",
     "einops",
     "chardet",


### PR DESCRIPTION
Seems Gradio 4 has removed a feature expected by the included app. Probably easy to repair but in the meantime, perhaps best to ensure the setup.py takes the last working release of Gradio.